### PR TITLE
Allow for tcomb in type check function

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -37,7 +37,24 @@ module.exports = function (type, value) {
   }
 
   if (types.indexOf(type) === -1 && typeof type === 'function') {
-    return type(value);
+    var result;
+    try {
+      result = type(value);
+    } catch(e) {
+      console.log('Type Error:', e);
+    }
+
+    if (result === undefined) return false;
+    
+    // tcomb returns the value if it passes so 0 and false evaluate to 
+    // a return value of false, where you actually want to test for number and boolean
+    if (typeof result === 'number') {
+      return true;
+    }
+    if (typeof result === 'boolean') {
+      return true;
+    }
+    return result;
   }
 
   return true;


### PR DESCRIPTION
tcomb returns the checked value if it passes assertions, eg. 0 is a `Number` but cerebral will return false because of type inference. `Boolean` of value `false` will return false, where you want it to return `true`.